### PR TITLE
[WOD-22112] Atualiza validação dos números de Inscrição Estadual das UFs GO, MS e PA

### DIFF
--- a/lib/br_documents/documents/ie/go.rb
+++ b/lib/br_documents/documents/ie/go.rb
@@ -8,7 +8,7 @@ module BRDocuments
 
     set_pretty_format_mask %(%s.%s.%s-%s)
 
-    set_fixed_digits [10, 11, 15, 20]
+    set_fixed_digits [10, 11, *20..29]
 
     def self.valid_fixed_digits?(number)
       number = new(number).normalize

--- a/lib/br_documents/documents/ie/ms.rb
+++ b/lib/br_documents/documents/ie/ms.rb
@@ -4,11 +4,21 @@ module BRDocuments
 
     set_verify_digits_weights first: %w(9 8 7 6 5 4 3 2)
 
-    set_format_regexp %r{^(28)[-.]?(\d{3})[-.]?(\d{3})[\/-]?(\d{1})}
+    set_format_regexp %r{^(28|50)[-.]?(\d{3})[-.]?(\d{3})[\/-]?(\d{1})}
 
     set_pretty_format_mask %(%s.%s.%s-%s)
 
-    set_fixed_digits [2, 8]
+    set_fixed_digits [28, 50]
 
+    def self.valid_fixed_digits?(number)
+      number = new(number).normalize
+      current = number[0..1].join.to_i
+
+      self.const_get('FIXED_INITIAL_NUMBERS').member?(current)
+    end
+
+    def self.fixed_digits
+      super.sample.to_s.split(//).map(&:to_i)
+    end
   end
 end

--- a/lib/br_documents/documents/ie/pa.rb
+++ b/lib/br_documents/documents/ie/pa.rb
@@ -4,11 +4,21 @@ module BRDocuments
 
     set_verify_digits_weights first: %w(9 8 7 6 5 4 3 2)
 
-    set_format_regexp %r{^(15)[.-]?(\d{3})[-.]?(\d{3})[-.]?(\d{1})}
+    set_format_regexp %r{^(15|7[5-9])[.-]?(\d{3})[-.]?(\d{3})[-.]?(\d{1})}
 
     set_pretty_format_mask %(%s.%s.%s-%s)
 
-    set_fixed_digits [1, 5]
+    set_fixed_digits [15, *75..79]
 
+    def self.valid_fixed_digits?(number)
+      number = new(number).normalize
+      current = number[0..1].join.to_i
+
+      const_get('FIXED_INITIAL_NUMBERS').member?(current)
+    end
+
+    def self.fixed_digits
+      super.sample.to_s.split(//).map(&:to_i)
+    end
   end
 end

--- a/spec/documents/ie/go_spec.rb
+++ b/spec/documents/ie/go_spec.rb
@@ -13,6 +13,9 @@ describe BRDocuments::IE::GO do
       10.139.969-3
       10139969-3
       101399693
+      20.687.704-8
+      20687704-8
+      206877048
     )
 
     @invalid_numbers = %w(

--- a/spec/documents/ie/go_spec.rb
+++ b/spec/documents/ie/go_spec.rb
@@ -22,6 +22,7 @@ describe BRDocuments::IE::GO do
       10.139.969-31
       10.139.96-31
       110.139.969-3
+      259876543
     )
 
     @valid_verify_digits = {

--- a/spec/documents/ie/ms_spec.rb
+++ b/spec/documents/ie/ms_spec.rb
@@ -13,6 +13,9 @@ describe BRDocuments::IE::MS do
       28.008.461-7
       28.008461-7
       280084617
+      50.964.930-0
+      50.964930-0
+      509649300
     )
 
     @invalid_numbers = %w(

--- a/spec/documents/ie/ms_spec.rb
+++ b/spec/documents/ie/ms_spec.rb
@@ -22,6 +22,7 @@ describe BRDocuments::IE::MS do
       28.008.461-71
       28.1008.461-7
       28.108.46-7
+      509876543
     )
 
     @valid_verify_digits = {

--- a/spec/documents/ie/pa_spec.rb
+++ b/spec/documents/ie/pa_spec.rb
@@ -13,6 +13,9 @@ describe BRDocuments::IE::PA do
       15.069.665-5
       15069665-5
       150696655
+      75.000.002-3
+      75000002-3
+      750000023
     )
 
     @invalid_numbers = %w(

--- a/spec/documents/ie/pa_spec.rb
+++ b/spec/documents/ie/pa_spec.rb
@@ -13,15 +13,16 @@ describe BRDocuments::IE::PA do
       15.069.665-5
       15069665-5
       150696655
-      75.000.002-3
-      75000002-3
-      750000023
+      75.069.570-6
+      75069570-6
+      750695706
     )
 
     @invalid_numbers = %w(
       1506966551
       150696651
       1510696655
+      761234567
     )
 
     @valid_verify_digits = {
@@ -35,6 +36,7 @@ describe BRDocuments::IE::PA do
       '15.074.998-8', # COMPANHIA DE SANEAMENTO DO PARA
       '15.286.652-3', # Companhia Docas do Para
       '15.050.675-9', # Banpara - Banco do Estado do Para S A 26/10/1961
+      '75.069.570-6', # Longshan Xiang
     ]
   end
 

--- a/spec/documents/ie/shared_examples.rb
+++ b/spec/documents/ie/shared_examples.rb
@@ -1,7 +1,9 @@
 RSpec.shared_examples "IE basic specs" do
   it 'must generate root numbers with fixed numbers' do
 
-    next if [BRDocuments::IE::RJ, BRDocuments::IE::BA, BRDocuments::IE::GO, BRDocuments::IE::MT].member?(described_class)
+    next if [
+        BRDocuments::IE::RJ, BRDocuments::IE::BA, BRDocuments::IE::GO, BRDocuments::IE::MT, BRDocuments::IE::PA, BRDocuments::IE::MS
+      ].member?(described_class)
 
     number = described_class.generate_root_numbers # without formatting
 
@@ -32,7 +34,9 @@ RSpec.shared_examples "IE basic specs" do
   end
 
   it 'must generate new numbers including initial fixed numbers' do
-    next if [BRDocuments::IE::RJ, BRDocuments::IE::BA, BRDocuments::IE::GO, BRDocuments::IE::MT].member?(described_class)
+    next if [
+        BRDocuments::IE::RJ, BRDocuments::IE::BA, BRDocuments::IE::GO, BRDocuments::IE::MT, BRDocuments::IE::PA, BRDocuments::IE::MS
+      ].member?(described_class)
 
     10.times {
       number = described_class.generate


### PR DESCRIPTION
Atualiza a validação de IE para os estados de Goiás, Mato Grosso do Sul e Pará, de acordo com as informações obtidas do Sintegra:

<img width="1914" height="463" alt="image" src="https://github.com/user-attachments/assets/00a8a4af-b385-44a4-8630-585ed637b105" />
<img width="1918" height="495" alt="image" src="https://github.com/user-attachments/assets/cfc17280-bbcb-4cd1-aa51-7efe0e8239ad" />
<img width="1914" height="477" alt="image" src="https://github.com/user-attachments/assets/a5c06e77-a5b6-480c-8fff-c8e166ab7fae" />
